### PR TITLE
Specify files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "email": "mail@substack.net",
     "url": "http://substack.net"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Currently the `example` and `test` folders and various dotfiles such as `.travis.yml` are being published to npm. Considering that they make up about half of the file size of this package, it would be worthwhile to exclude them.

This PR excludes them using the using the [`files`](https://docs.npmjs.com/files/package.json#files) whitelist in the `package.json`.