### PR TITLE
Remove polyfills for ES5 features

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function (obj, opts) {
         if (typeof node !== 'object' || node === null) {
             return JSON.stringify(node);
         }
-        if (isArray(node)) {
+        if (Array.isArray(node)) {
             var out = [];
             for (var i = 0; i < node.length; i++) {
                 var item = stringify(node, i, node[i], level+1) || JSON.stringify(null);
@@ -48,7 +48,7 @@ module.exports = function (obj, opts) {
             }
             else seen.push(node);
 
-            var keys = objectKeys(node).sort(cmp && cmp(node));
+            var keys = Object.keys(node).sort(cmp && cmp(node));
             var out = [];
             for (var i = 0; i < keys.length; i++) {
                 var key = keys[i];
@@ -66,17 +66,4 @@ module.exports = function (obj, opts) {
             return '{' + out.join(',') + indent + '}';
         }
     })({ '': obj }, '', obj, 0);
-};
-
-var isArray = Array.isArray || function (x) {
-    return {}.toString.call(x) === '[object Array]';
-};
-
-var objectKeys = Object.keys || function (obj) {
-    var has = Object.prototype.hasOwnProperty || function () { return true };
-    var keys = [];
-    for (var key in obj) {
-        if (has.call(obj, key)) keys.push(key);
-    }
-    return keys;
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "testling": {
     "files": "test/*.js",
     "browsers": [
-      "ie/8..latest",
+      "ie/9..latest",
       "ff/5", "ff/latest",
       "chrome/15", "chrome/latest",
       "safari/latest",


### PR DESCRIPTION
This breaks compatibility with Internet Explorer 8 which is technically a breaking change but today the impact ought to be quite limited. IMO the added compatibility it not worth the bytes it uses. The polyfills are also quite easy to add for any users of this library.

Test are also already failing on IE8 without this change: https://ci.testling.com/substack/json-stable-stringify